### PR TITLE
Fix strict standards errors in processors, success() signature not matching

### DIFF
--- a/core/components/bigbrother/processors/mgr/manage/accountlist.class.php
+++ b/core/components/bigbrother/processors/mgr/manage/accountlist.class.php
@@ -53,7 +53,7 @@ class getAccountList extends modProcessor {
         }
         //$this->ga->updateOption('total_account', $result['totalResults']);
         $this->ga->updateOption('total_account', $total);
-        return $this->successBB( $output );
+        return $this->success( '', $output );
     }
 
     /**
@@ -86,7 +86,7 @@ class getAccountList extends modProcessor {
      * @param array $output
      * @return string
      */
-    public function successBB( $output ){
+    public function success( $msg = '', $output = null ){
         $response = array(
             'success' => true,
             'results' => $output,

--- a/core/components/bigbrother/processors/mgr/report/area.class.php
+++ b/core/components/bigbrother/processors/mgr/report/area.class.php
@@ -28,7 +28,7 @@ class getAreaSerieProcessor extends modProcessor {
         $cacheKey = $this->ga->cacheKey;
         $fromCache = $this->modx->cacheManager->get($cacheKey);
         if( !empty($fromCache) ){
-            return $this->successBB($fromCache, true);
+            return $this->success('Fetched data from cache', $fromCache, true);
         }
         if( !$this->ga->loadOAuth() ){
             return $this->failure('Could not load the OAuth file.');
@@ -39,7 +39,7 @@ class getAreaSerieProcessor extends modProcessor {
         $this->addSerie();
 
         $this->modx->cacheManager->set($cacheKey, $this->series, $this->ga->getOption('cache_timeout'));
-        return $this->successBB( $this->series );
+        return $this->success( 'Fetched data from Google', $this->series );
     }
 
     /**
@@ -71,7 +71,7 @@ class getAreaSerieProcessor extends modProcessor {
      * @param boolean $fromCache
      * @return string
      */
-    public function successBB( $series, $fromCache = false ){
+    public function success( $msg = '', $series = null, $fromCache = false ){
         $response = array(
             'success' => true,
             'series' => $series,

--- a/core/components/bigbrother/processors/mgr/report/areacompare.class.php
+++ b/core/components/bigbrother/processors/mgr/report/areacompare.class.php
@@ -28,7 +28,7 @@ class getSeriesForComparisonAreaChart extends modProcessor {
         $cacheKey = md5($this->ga->cacheKey /*. $beforeDate*/);
         $fromCache = $this->modx->cacheManager->get($cacheKey);
         if( !empty($fromCache) ){
-            return $this->successBB($fromCache, true);
+            return $this->success('Fetched data from cache', $fromCache);
         }
         if( !$this->ga->loadOAuth() ){
             return $this->failure('Could not load the OAuth file.');
@@ -46,7 +46,7 @@ class getSeriesForComparisonAreaChart extends modProcessor {
         $this->addSerie();
 
         $this->modx->cacheManager->set($cacheKey, $this->series, $this->ga->getOption('cache_timeout'));
-        return $this->successBB( $this->series );
+        return $this->success('Fetched data from Google', $this->series);
     }
 
     /**
@@ -85,7 +85,7 @@ class getSeriesForComparisonAreaChart extends modProcessor {
      * @param boolean $fromCache
      * @return string
      */
-    public function successBB( $series, $fromCache = false ){
+    public function success( $msg = '', $series = null, $fromCache = false ){
         $response = array(
             'success' => true,
             'series' => $series,

--- a/core/components/bigbrother/processors/mgr/report/getlist.class.php
+++ b/core/components/bigbrother/processors/mgr/report/getlist.class.php
@@ -40,7 +40,7 @@ class getDataForGrid extends modProcessor {
         $cacheKey = $this->ga->cacheKey;
         $fromCache = $this->modx->cacheManager->get($cacheKey);
         if( !empty($fromCache) ){
-            return $this->successBB( $fromCache, true );
+            return $this->success( 'Fetched data from cache', $fromCache, true );
         }
         if( !$this->ga->loadOAuth() ){
             return $this->failure('Could not load the OAuth file.');
@@ -51,7 +51,7 @@ class getDataForGrid extends modProcessor {
         $this->visits = $this->ga->getTotalVisits($date['begin'], $date['end']);
         $response = $this->iterate();
         $this->modx->cacheManager->set($cacheKey, $response, $this->ga->getOption('cache_timeout'));
-        return $this->successBB( $response );
+        return $this->success( 'Fetched data from Google', $response );
     }
 
     /**
@@ -78,7 +78,7 @@ class getDataForGrid extends modProcessor {
      * @param array $output
      * @return string
      */
-    public function successBB( $output, $fromCache = false ){
+    public function success( $msg = '', $output = null, $fromCache = false ){
         $response = array_merge( array(
             'success' => true,
             'fromCache' => $fromCache,

--- a/core/components/bigbrother/processors/mgr/report/metas.class.php
+++ b/core/components/bigbrother/processors/mgr/report/metas.class.php
@@ -30,7 +30,7 @@ class getMetas extends modProcessor {
         $cacheKey = $this->ga->cacheKey;
         $fromCache = $this->modx->cacheManager->get($cacheKey);
         if( !empty($fromCache) ){
-            return $this->successBB($fromCache, true);
+            return $this->success('Fetched data from cache', $fromCache, true);
         }
         if( !$this->ga->loadOAuth() ){
             return $this->failure('Could not load the OAuth file.');
@@ -46,7 +46,7 @@ class getMetas extends modProcessor {
         }
         $this->compareData();
         $this->modx->cacheManager->set($cacheKey, $this->output, $this->ga->getOption('cache_timeout'));
-        return $this->successBB( $this->output );
+        return $this->success( 'Fetched data from Google', $this->output );
     }
 
     /**
@@ -116,7 +116,7 @@ class getMetas extends modProcessor {
      * @param boolean $fromCache
      * @return string
      */
-    public function successBB( $output, $fromCache = false ){
+    public function success( $msg = '', $output = null, $fromCache = false ){
         $response = array_merge(array(
             'success' => true,
             'fromCache' => $fromCache,

--- a/core/components/bigbrother/processors/mgr/report/pie.class.php
+++ b/core/components/bigbrother/processors/mgr/report/pie.class.php
@@ -39,7 +39,7 @@ class getPieSerieProcessor extends modProcessor {
         $cacheKey = $this->ga->cacheKey;
         $fromCache = $this->modx->cacheManager->get($cacheKey);
         if( !empty($fromCache) ){
-            return $this->successBB($fromCache, true);
+            return $this->success('Fetched data from cache', $fromCache, true);
         }
         if( !$this->ga->loadOAuth() ){
             return $this->failure('Could not load the OAuth file.');
@@ -50,7 +50,7 @@ class getPieSerieProcessor extends modProcessor {
         $this->addSerie();
 
         $this->modx->cacheManager->set($cacheKey, $this->series, $this->ga->getOption('cache_timeout'));
-        return $this->successBB( $this->series );
+        return $this->success( 'Fetched data from Google', $this->series );
     }
 
     /**
@@ -73,7 +73,7 @@ class getPieSerieProcessor extends modProcessor {
      * @param boolean $fromCache
      * @return string
      */
-    public function successBB( $series, $fromCache = false ){
+    public function success( $msg = '', $series = null, $fromCache = false ){
         $response = array(
             'success' => true,
             'series' => $series,


### PR DESCRIPTION
Fixes https://github.com/lossendae/BigBrother/issues/32

not sure about the comment from @rtripault which says this should be fixed in master branch. With the proposed changes, the signature of success() matches the one from modProcessor and the extra works again. Would be nice to have a new release with this fix soon as my hoster switched to PHP 5.4 (as lowest PHP version) and BigBrother is not working on any installs anymore.